### PR TITLE
Shorten task uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 unfog.cabal
+dist-newstyle
 *~

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ library:
   - random
   - time
   - uuid
+  - containers
 
 executables:
   unfog:

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -36,9 +36,10 @@ handle arg = do
   let cmds = parseCommands now tzone state rndId arg
   let evts = concatMap (execute state) cmds
   let state' = State.applyAll state evts
+  let shortenId' = shortenId $ getShortIdLength $ State.getTasks state
   Store.appendFile evts
   State.writeFile state'
-  notify cmds subscribers
+  notify shortenId' cmds subscribers
 
 parseCommands :: UTCTime -> TimeZone -> State -> Id -> Arg.Command -> [Command]
 parseCommands now tzone state id (Arg.Add desc proj due jsonOpt) = [addTask now tzone (parseResponseType jsonOpt) state id desc proj due]
@@ -162,34 +163,36 @@ editContext = EditContext
 
 -- Subscribers
 
-type Subscriber = Command -> IO ()
+type ShortenId = Id -> ShortId
 
-notify :: [Command] -> [Subscriber] -> IO ()
-notify cmds subs = mapM_ (notify' cmds) subs
+type Subscriber = ShortenId -> Command -> IO ()
+
+notify :: ShortenId -> [Command] -> [Subscriber] -> IO ()
+notify shortenId cmds subs = mapM_ (notify' cmds) subs
   where
-    notify' cmds subscriber = mapM_ subscriber cmds
+    notify' cmds subscriber = mapM_ (subscriber shortenId) cmds
 
 subscribers :: [Subscriber]
 subscribers = [logger]
 
 logger :: Subscriber
-logger cmd = case cmd of
-  AddTask _ Text id _ proj _ -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m added%s" id $ showIfJust " to project \x1b[34m%s\x1b[0m" proj
-  AddTask _ Json id _ proj _ -> send Json $ MessageResponse $ printf "Task %s added%s" id $ showIfJust " to project %s" proj
-  EditTask _ Text id _ _ _ -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m edited" id
-  EditTask _ Json id _ _ _ -> send Json $ MessageResponse $ printf "Task %s edited" id
-  StartTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m started" id
-  StartTask _ Json id -> send Json $ MessageResponse $ printf "Task %s started" id
-  StopTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m stopped" id
-  StopTask _ Json id -> send Json $ MessageResponse $ printf "Task %s stopped" id
-  DoTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m done" id
-  DoTask _ Json id -> send Json $ MessageResponse $ printf "Task %s done" id
-  UndoTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m undone" id
-  UndoTask _ Json id -> send Json $ MessageResponse $ printf "Task %s undone" id
-  DeleteTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m deleted" id
-  DeleteTask _ Json id -> send Json $ MessageResponse $ printf "Task %s deleted" id
-  UndeleteTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m undeleted" id
-  UndeleteTask _ Json id -> send Json $ MessageResponse $ printf "Task %s undeleted" id
+logger shortenId cmd = case cmd of
+  AddTask _ Text id _ proj _ -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m added%s" (shortenId id) $ showIfJust " to project \x1b[34m%s\x1b[0m" proj
+  AddTask _ Json id _ proj _ -> send Json $ MessageResponse $ printf "Task %s added%s" (shortenId id) $ showIfJust " to project %s" proj
+  EditTask _ Text id _ _ _ -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m edited" (shortenId id)
+  EditTask _ Json id _ _ _ -> send Json $ MessageResponse $ printf "Task %s edited" (shortenId id)
+  StartTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m started" (shortenId id)
+  StartTask _ Json id -> send Json $ MessageResponse $ printf "Task %s started" (shortenId id)
+  StopTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m stopped" (shortenId id)
+  StopTask _ Json id -> send Json $ MessageResponse $ printf "Task %s stopped" (shortenId id)
+  DoTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m done" (shortenId id)
+  DoTask _ Json id -> send Json $ MessageResponse $ printf "Task %s done" (shortenId id)
+  UndoTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m undone" (shortenId id)
+  UndoTask _ Json id -> send Json $ MessageResponse $ printf "Task %s undone" (shortenId id)
+  DeleteTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m deleted" (shortenId id)
+  DeleteTask _ Json id -> send Json $ MessageResponse $ printf "Task %s deleted" (shortenId id)
+  UndeleteTask _ Text id -> send Text $ MessageResponse $ printf "Task \x1b[31m%s\x1b[0m undeleted" (shortenId id)
+  UndeleteTask _ Json id -> send Json $ MessageResponse $ printf "Task %s undeleted" (shortenId id)
   EditContext _ rtype Nothing -> send rtype $ MessageResponse "Context cleared"
   EditContext _ Text (Just ctx) -> send Text $ MessageResponse $ printf "Project \x1b[34m%s\x1b[0m defined as context" ctx
   EditContext _ Json (Just ctx) -> send Json $ MessageResponse $ printf "Project %s defined as context" ctx

--- a/src/Query.hs
+++ b/src/Query.hs
@@ -7,14 +7,16 @@ import Data.Maybe (isJust, isNothing)
 import Data.Time (TimeZone, UTCTime, getCurrentTime, getCurrentTimeZone)
 import Response
 import State (State (..))
-import qualified State (new, readFile, rebuild)
+import qualified State (getTasks, new, readFile, rebuild)
 import qualified Store (readFile)
 import Task
 import Worktime
 
+type IdLength = Int
+
 data Query
-  = ShowTasks UTCTime ResponseType Project [Task]
-  | ShowTask UTCTime ResponseType Task
+  = ShowTasks UTCTime IdLength ResponseType Project [Task]
+  | ShowTask UTCTime IdLength ResponseType Task
   | ShowWtime UTCTime ResponseType MoreOpt [DailyWorktime]
   | ShowStatus UTCTime ResponseType (Maybe Task)
   | Error ResponseType String
@@ -24,32 +26,33 @@ handle :: Arg.Query -> IO ()
 handle arg = do
   now <- getCurrentTime
   state <- State.readFile <|> (State.rebuild <$> Store.readFile) <|> return State.new
-  let query = parseQuery now state arg
+  let idLength = getShortIdLength $ State.getTasks state
+  let query = parseQuery now idLength state arg
   execute query
 
-parseQuery :: UTCTime -> State -> Arg.Query -> Query
-parseQuery now state (Arg.List jsonOpt) = showTasks now state jsonOpt
-parseQuery now state (Arg.Info id jsonOpt) = showTask now state id jsonOpt
-parseQuery now state (Arg.Wtime proj fromOpt toOpt moreOpt jsonOpt) = showWtime now state proj fromOpt toOpt moreOpt jsonOpt
-parseQuery now state (Arg.Status moreOpt jsonOpt) = showStatus now state moreOpt jsonOpt
+parseQuery :: UTCTime -> IdLength -> State -> Arg.Query -> Query
+parseQuery now idLength state (Arg.List jsonOpt) = showTasks now idLength state jsonOpt
+parseQuery now idLength state (Arg.Info id jsonOpt) = showTask now idLength state id jsonOpt
+parseQuery now _idLength state (Arg.Wtime proj fromOpt toOpt moreOpt jsonOpt) = showWtime now state proj fromOpt toOpt moreOpt jsonOpt
+parseQuery now _idLength state (Arg.Status moreOpt jsonOpt) = showStatus now state moreOpt jsonOpt
 
 execute :: Query -> IO ()
-execute (ShowTasks now rtype ctx tasks) = send rtype (TasksResponse now ctx tasks)
-execute (ShowTask now rtype task) = send rtype (TaskResponse now task)
+execute (ShowTasks now idLength rtype ctx tasks) = send rtype (TasksResponse now idLength ctx tasks)
+execute (ShowTask now idLength rtype task) = send rtype (TaskResponse now idLength task)
 execute (ShowWtime now rtype moreOpt wtimes) = send rtype (WtimeResponse now moreOpt wtimes)
 execute (ShowStatus now rtype task) = send rtype (StatusResponse now task)
 execute (Error rtype msg) = send rtype (ErrorResponse msg)
 
-showTasks :: UTCTime -> State -> JsonOpt -> Query
-showTasks now (State ctx tasks) jsonOpt = ShowTasks now rtype ctx tasks'
+showTasks :: UTCTime -> IdLength -> State -> JsonOpt -> Query
+showTasks now idLength (State ctx tasks) jsonOpt = ShowTasks now idLength rtype ctx tasks'
   where
     rtype = parseResponseType jsonOpt
     tasks' = filterWith [notDone, notDeleted, matchContext ctx] tasks
 
-showTask :: UTCTime -> State -> Id -> JsonOpt -> Query
-showTask now (State _ tasks) id jsonOpt = case findById id tasks of
+showTask :: UTCTime -> IdLength -> State -> Id -> JsonOpt -> Query
+showTask now idLength (State _ tasks) id jsonOpt = case findById id tasks of
   Nothing -> Error rtype "task not found"
-  Just task -> ShowTask now rtype task
+  Just task -> ShowTask now idLength rtype task
   where
     rtype = parseResponseType jsonOpt
 

--- a/test/CommandSpec.hs
+++ b/test/CommandSpec.hs
@@ -35,85 +35,85 @@ spec = parallel $ do
       parseCommands' (Arg.Edit "id" "desc" (Just "proj") Nothing False) `shouldBe` [EditTask now Text "id" "desc" (Just "proj") Nothing]
       parseCommands' (Arg.Edit "id" "desc" Nothing (Just now) False) `shouldBe` [EditTask now Text "id" "desc" Nothing (Just now)]
       parseCommands' (Arg.Edit "id" "desc" Nothing (Just now) False) `shouldBe` [EditTask now Text "id" "desc" Nothing (Just now)]
-      parseCommands' (Arg.Edit "id-unknown" "desc" Nothing Nothing False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Edit "idunknown" "desc" Nothing Nothing False) `shouldBe` [Error Text "task not found"]
 
     it "parse start command" $ do
       let taskA = Task.new {_id = "id"}
-      let taskB = Task.new {_id = "id-started", _active = Just now}
-      let taskC = Task.new {_id = "id-done", _done = Just now}
-      let taskD = Task.new {_id = "id-deleted", _deleted = Just now}
+      let taskB = Task.new {_id = "idstarted", _active = Just now}
+      let taskC = Task.new {_id = "iddone", _done = Just now}
+      let taskD = Task.new {_id = "iddeleted", _deleted = Just now}
       let state = State.new {_tasks = [taskA, taskB, taskC, taskD]}
       let parseCommands' = parseCommands now tzone state ""
       parseCommands' (Arg.Start [] False) `shouldBe` []
       parseCommands' (Arg.Start ["id"] False) `shouldBe` [StartTask now Text "id"]
       parseCommands' (Arg.Start ["id"] True) `shouldBe` [StartTask now Json "id"]
-      parseCommands' (Arg.Start ["id-started"] False) `shouldBe` [Error Text "task already started"]
-      parseCommands' (Arg.Start ["id-done"] False) `shouldBe` [Error Text "task already done"]
-      parseCommands' (Arg.Start ["id-deleted"] False) `shouldBe` [Error Text "task already deleted"]
-      parseCommands' (Arg.Start ["id-unknown"] False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Start ["idstarted"] False) `shouldBe` [Error Text "task already started"]
+      parseCommands' (Arg.Start ["iddone"] False) `shouldBe` [Error Text "task already done"]
+      parseCommands' (Arg.Start ["iddeleted"] False) `shouldBe` [Error Text "task already deleted"]
+      parseCommands' (Arg.Start ["idunknown"] False) `shouldBe` [Error Text "task not found"]
 
     it "parse stop command" $ do
       let taskA = Task.new {_id = "id", _active = Just now}
-      let taskB = Task.new {_id = "id-stopped"}
-      let taskC = Task.new {_id = "id-done", _done = Just now}
-      let taskD = Task.new {_id = "id-deleted", _deleted = Just now}
+      let taskB = Task.new {_id = "idstopped"}
+      let taskC = Task.new {_id = "iddone", _done = Just now}
+      let taskD = Task.new {_id = "iddeleted", _deleted = Just now}
       let state = State.new {_tasks = [taskA, taskB, taskC, taskD]}
       let parseCommands' = parseCommands now tzone state ""
       parseCommands' (Arg.Stop [] False) `shouldBe` []
       parseCommands' (Arg.Stop ["id"] False) `shouldBe` [StopTask now Text "id"]
       parseCommands' (Arg.Stop ["id"] True) `shouldBe` [StopTask now Json "id"]
-      parseCommands' (Arg.Stop ["id-stopped"] False) `shouldBe` [Error Text "task already stopped"]
-      parseCommands' (Arg.Stop ["id-done"] False) `shouldBe` [Error Text "task already done"]
-      parseCommands' (Arg.Stop ["id-deleted"] False) `shouldBe` [Error Text "task already deleted"]
-      parseCommands' (Arg.Stop ["id-unknown"] False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Stop ["idstopped"] False) `shouldBe` [Error Text "task already stopped"]
+      parseCommands' (Arg.Stop ["iddone"] False) `shouldBe` [Error Text "task already done"]
+      parseCommands' (Arg.Stop ["iddeleted"] False) `shouldBe` [Error Text "task already deleted"]
+      parseCommands' (Arg.Stop ["idunknown"] False) `shouldBe` [Error Text "task not found"]
 
     it "parse do command" $ do
       let taskA = Task.new {_id = "id"}
-      let taskB = Task.new {_id = "id-done", _done = Just now}
-      let taskC = Task.new {_id = "id-deleted", _deleted = Just now}
+      let taskB = Task.new {_id = "iddone", _done = Just now}
+      let taskC = Task.new {_id = "iddeleted", _deleted = Just now}
       let state = State.new {_tasks = [taskA, taskB, taskC]}
       let parseCommands' = parseCommands now tzone state ""
       parseCommands' (Arg.Do [] False) `shouldBe` []
       parseCommands' (Arg.Do ["id"] False) `shouldBe` [DoTask now Text "id"]
       parseCommands' (Arg.Do ["id"] True) `shouldBe` [DoTask now Json "id"]
-      parseCommands' (Arg.Do ["id-done"] False) `shouldBe` [Error Text "task already done"]
-      parseCommands' (Arg.Do ["id-deleted"] False) `shouldBe` [Error Text "task already deleted"]
-      parseCommands' (Arg.Do ["id-unknown"] False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Do ["iddone"] False) `shouldBe` [Error Text "task already done"]
+      parseCommands' (Arg.Do ["iddeleted"] False) `shouldBe` [Error Text "task already deleted"]
+      parseCommands' (Arg.Do ["idunknown"] False) `shouldBe` [Error Text "task not found"]
 
     it "parse undo command" $ do
       let taskA = Task.new {_id = "id", _done = Just now}
-      let taskB = Task.new {_id = "id-undone"}
-      let taskC = Task.new {_id = "id-deleted", _deleted = Just now}
+      let taskB = Task.new {_id = "idundone"}
+      let taskC = Task.new {_id = "iddeleted", _deleted = Just now}
       let state = State.new {_tasks = [taskA, taskB, taskC]}
       let parseCommands' = parseCommands now tzone state ""
       parseCommands' (Arg.Undo [] False) `shouldBe` []
       parseCommands' (Arg.Undo ["id"] False) `shouldBe` [UndoTask now Text "id"]
       parseCommands' (Arg.Undo ["id"] True) `shouldBe` [UndoTask now Json "id"]
-      parseCommands' (Arg.Undo ["id-undone"] False) `shouldBe` [Error Text "task not yet done"]
-      parseCommands' (Arg.Undo ["id-deleted"] False) `shouldBe` [Error Text "task already deleted"]
-      parseCommands' (Arg.Undo ["id-unknown"] False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Undo ["idundone"] False) `shouldBe` [Error Text "task not yet done"]
+      parseCommands' (Arg.Undo ["iddeleted"] False) `shouldBe` [Error Text "task already deleted"]
+      parseCommands' (Arg.Undo ["idunknown"] False) `shouldBe` [Error Text "task not found"]
 
     it "parse delete command" $ do
       let taskA = Task.new {_id = "id"}
-      let taskB = Task.new {_id = "id-deleted", _deleted = Just now}
+      let taskB = Task.new {_id = "iddeleted", _deleted = Just now}
       let state = State.new {_tasks = [taskA, taskB]}
       let parseCommands' = parseCommands now tzone state ""
       parseCommands' (Arg.Delete [] False) `shouldBe` []
       parseCommands' (Arg.Delete ["id"] False) `shouldBe` [DeleteTask now Text "id"]
       parseCommands' (Arg.Delete ["id"] True) `shouldBe` [DeleteTask now Json "id"]
-      parseCommands' (Arg.Delete ["id-deleted"] False) `shouldBe` [Error Text "task already deleted"]
-      parseCommands' (Arg.Delete ["id-unknown"] False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Delete ["iddeleted"] False) `shouldBe` [Error Text "task already deleted"]
+      parseCommands' (Arg.Delete ["idunknown"] False) `shouldBe` [Error Text "task not found"]
 
     it "parse undelete command" $ do
       let taskA = Task.new {_id = "id", _deleted = Just now}
-      let taskB = Task.new {_id = "id-undeleted"}
+      let taskB = Task.new {_id = "idundeleted"}
       let state = State.new {_tasks = [taskA, taskB]}
       let parseCommands' = parseCommands now tzone state ""
       parseCommands' (Arg.Undelete [] False) `shouldBe` []
       parseCommands' (Arg.Undelete ["id"] False) `shouldBe` [UndeleteTask now Text "id"]
       parseCommands' (Arg.Undelete ["id"] True) `shouldBe` [UndeleteTask now Json "id"]
-      parseCommands' (Arg.Undelete ["id-undeleted"] False) `shouldBe` [Error Text "task not yet deleted"]
-      parseCommands' (Arg.Undelete ["id-unknown"] False) `shouldBe` [Error Text "task not found"]
+      parseCommands' (Arg.Undelete ["idundeleted"] False) `shouldBe` [Error Text "task not yet deleted"]
+      parseCommands' (Arg.Undelete ["idunknown"] False) `shouldBe` [Error Text "task not found"]
 
   it "execute" $ do
     execute State.new (AddTask now Text "id" "desc" Nothing Nothing) `shouldBe` [TaskAdded now "id" "desc" Nothing Nothing]

--- a/test/IdSpec.hs
+++ b/test/IdSpec.hs
@@ -1,0 +1,35 @@
+module IdSpec (spec) where
+
+import Data.Time
+import Task
+import Test.Hspec
+
+aTask :: Task
+aTask =
+  Task
+    { _id = "00000000-0000-0000-0000-000000000000",
+      _desc = "",
+      _project = Nothing,
+      _starts = [],
+      _stops = [],
+      _due = Nothing,
+      _active = Nothing,
+      _done = Nothing,
+      _deleted = Nothing
+    }
+
+spec :: Spec
+spec = parallel $ do
+  it "Finds the minimum length of ids so that ids are non-ambigous" $ do
+    getShortIdLength
+      [ aTask {_id = "12345678-0000-0000-0000-000000000000"},
+        aTask {_id = "00000000-0000-0000-0000-000000000000"}
+      ]
+      `shouldBe` 4
+
+    getShortIdLength
+      [ aTask {_id = "12345678-0000-0000-0000-000000000000"},
+        aTask {_id = "00000000-0000-0000-0000-000000000000"},
+        aTask {_id = "00000001-0000-0000-0000-000000000000"}
+      ]
+      `shouldBe` 8

--- a/test/QuerySpec.hs
+++ b/test/QuerySpec.hs
@@ -16,29 +16,30 @@ spec :: Spec
 spec = parallel $ do
   describe "parse queries" $ do
     let now = read "2020-01-01 00:00:00 UTC" :: UTCTime
+    let idLength = 7
 
     it "parse list query" $ do
       let taskA = Task.new {_id = "id"}
       let taskB = Task.new {_id = "id-proj", _project = Just "proj"}
       let taskC = Task.new {_id = "id-done", _done = Just now}
       let taskD = Task.new {_id = "id-deleted", _done = Just now}
-      let parseQuery' ctx = parseQuery now State.new {_tasks = [taskA, taskB, taskC, taskD], _ctx = ctx}
-      parseQuery' Nothing (Arg.List False) `shouldBe` ShowTasks now Text Nothing [taskA, taskB]
-      parseQuery' Nothing (Arg.List True) `shouldBe` ShowTasks now Json Nothing [taskA, taskB]
-      parseQuery' (Just "proj") (Arg.List False) `shouldBe` ShowTasks now Text (Just "proj") [taskB]
+      let parseQuery' ctx = parseQuery now idLength State.new {_tasks = [taskA, taskB, taskC, taskD], _ctx = ctx}
+      parseQuery' Nothing (Arg.List False) `shouldBe` ShowTasks now idLength Text Nothing [taskA, taskB]
+      parseQuery' Nothing (Arg.List True) `shouldBe` ShowTasks now idLength Json Nothing [taskA, taskB]
+      parseQuery' (Just "proj") (Arg.List False) `shouldBe` ShowTasks now idLength Text (Just "proj") [taskB]
 
     it "parse info query" $ do
       let task = Task.new {_id = "id"}
-      let parseQuery' = parseQuery now State.new {_tasks = [task]}
-      parseQuery' (Arg.Info "id" False) `shouldBe` ShowTask now Text task
-      parseQuery' (Arg.Info "id" True) `shouldBe` ShowTask now Json task
+      let parseQuery' = parseQuery now idLength State.new {_tasks = [task]}
+      parseQuery' (Arg.Info "id" False) `shouldBe` ShowTask now idLength Text task
+      parseQuery' (Arg.Info "id" True) `shouldBe` ShowTask now idLength Json task
       parseQuery' (Arg.Info "id-unknown" False) `shouldBe` Error Text "task not found"
 
     it "parse worktime query" $ do
       let start = read "2020-01-01 22:00:00 UTC" :: UTCTime
       let stop = read "2020-01-02 04:00:00 UTC" :: UTCTime
       let task = Task.new {_id = "id", _desc = "desc", _starts = [start], _stops = [stop]}
-      let parseQuery' tasks = parseQuery now State.new {_tasks = tasks}
+      let parseQuery' tasks = parseQuery now idLength State.new {_tasks = tasks}
       parseQuery' [] (Arg.Wtime Nothing Nothing Nothing False False) `shouldBe` ShowWtime now Text False []
       parseQuery' [] (Arg.Wtime Nothing Nothing Nothing False True) `shouldBe` ShowWtime now Json False []
       parseQuery' [] (Arg.Wtime Nothing Nothing Nothing True False) `shouldBe` ShowWtime now Text True []
@@ -54,7 +55,7 @@ spec = parallel $ do
       let taskA = Task.new {_id = "id"}
       let taskB = Task.new {_id = "id-started", _active = Just now}
       let taskC = Task.new {_id = "id-started-bis", _active = Just now}
-      let parseQuery' tasks = parseQuery now State.new {_tasks = tasks}
+      let parseQuery' tasks = parseQuery now idLength State.new {_tasks = tasks}
       parseQuery' [] (Arg.Status False False) `shouldBe` ShowStatus now Text Nothing
       parseQuery' [taskA] (Arg.Status False True) `shouldBe` ShowStatus now Json Nothing
       parseQuery' [taskB] (Arg.Status False False) `shouldBe` ShowStatus now Text (Just taskB)


### PR DESCRIPTION
This PR shorten task ids as much as possible.
`getShortIdLength :: [Task] -> Int` grows from 1 to 32 (the full uuid length) as long as the ids are not uniques. 
The complexity O(n) comes from the uniqueness ids check—a _Set_ is used for this purpose. 

**Note** that eventually I'd like to compute  _shortIdLength_ incrementally and persist it in the _State_ so that the complexity drop to O(1) 
